### PR TITLE
Fixes FHIR-29353, FHIR-29375

### DIFF
--- a/fsh/ig-data/input/pagecontent/index.md
+++ b/fsh/ig-data/input/pagecontent/index.md
@@ -144,11 +144,11 @@ In addition to sending Web Messaging Responses to the app, the EHR MAY also send
 The response message `payload` properties will vary based on the request `messageType`.  See message types below for details.
 
 #### Response Target Origin
-It is assumed that the EHR already knows the proper `targetOrigin` to use in its
-call to [`window.postMessage`] because it has demonstrated that it can SMART
-launch the app at a known SMART launch URL.  The SMART launch URL SHALL be
-prefixed with the proper value to use for the app `targetOrigin`, and the launch
-URL SHALL NOT redirect users to a different origin after launch.
+It is assumed that the EHR already knows the set of allowed web origins for each
+app, to be used in Web Messaging.  After launching an app, EHR SHOULD NOT process
+Web Messages originating from an origin outside this set.  If the app navigates
+users to an origin outside of this set, it SHOULD NOT depend on Web Messages
+reaching the EHR.
 
 #### Detailed Example Response
 In a more detailed example response, the EHR may send one return message like:


### PR DESCRIPTION
Updates the wording to allow redirects, so long as the redirected-to origin is known to the EHR (which allows the EHR to correctly filter received web messages by origin).