### PR TITLE
change package list, ig from https to http

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -1,6 +1,6 @@
 {
   "package-id": "hl7.fhir.uv.smart-web-messaging",
-  "canonical": "https://hl7.org/fhir/uv/smart-web-messaging",
+  "canonical": "http://hl7.org/fhir/uv/smart-web-messaging",
   "title": "SMART Web Messaging",
   "introduction": "This IG provides detailed guidance that helps implementers to use SMART Web Messaging to enable tight UI integration between EHRs and embedded SMART apps via HTML5’s Web Messaging. SMART Web Messaging allows applications to push unsigned orders, note snippets, risk scores, or UI suggestions directly to the clinician’s EHR session. Built on the browser’s javascript window.postMessage function, SMART Web Messaging is a simple, native API for health apps embedded within the user’s workflow.",
   "list": [
@@ -14,7 +14,7 @@
       "version": "1.0.0",
       "date": "2022-03-17",
       "desc": "STU 1 Release.  For a list of changes applied to this version see the SMART Web Messaging STU1 trackers at https://jira.hl7.org/issues/?filter=16804# (log in required)",
-      "path": "https://hl7.org/fhir/uv/smart-web-messaging/STU1",
+      "path": "http://hl7.org/fhir/uv/smart-web-messaging/STU1",
       "sequence": "STU1",
       "fhirversion": "4.0.1",
       "status": "trial-use",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,5 +1,5 @@
 id: hl7.fhir.uv.smart-web-messaging
-canonical: https://hl7.org/fhir/uv/smart-web-messaging
+canonical: http://hl7.org/fhir/uv/smart-web-messaging
 name: SmartWebMessaging
 title: "SMART Web Messaging"
 status: active


### PR DESCRIPTION
Lynn Laakso
2:49 PM (1 hour ago)
to Grahame, me, Lloyd

Eric,

Can you change the URL for the version 1.0.0 in the jira-spec-artifacts xml file to be http instead of https. I'm now getting  a Jira warning when trying to build.